### PR TITLE
ClubStatus auto-refresh bug fix

### DIFF
--- a/src/BoatTrackerBot/BoatTrackerBot.csproj.user
+++ b/src/BoatTrackerBot/BoatTrackerBot.csproj.user
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <UseIISExpress>true</UseIISExpress>
-    <NameOfLastUsedPublishProfile>BoatTrackerBot-dev - Web Deploy</NameOfLastUsedPublishProfile>
+    <NameOfLastUsedPublishProfile>BoatTrackerBot - Web Deploy</NameOfLastUsedPublishProfile>
     <WebStackScaffolding_ControllerDialogWidth>600</WebStackScaffolding_ControllerDialogWidth>
     <WebStackScaffolding_IsLayoutPageSelected>True</WebStackScaffolding_IsLayoutPageSelected>
     <WebStackScaffolding_IsPartialViewSelected>False</WebStackScaffolding_IsPartialViewSelected>

--- a/src/BoatTrackerBot/Views/ClubStatus/ClubStatus.cshtml
+++ b/src/BoatTrackerBot/Views/ClubStatus/ClubStatus.cshtml
@@ -9,7 +9,7 @@
 
 @section scripts {
     <script>
-        setTimeout(function(){ location.href = '@(refreshUrl)'; }, @(Model.PageRefreshTime) * 1000);
+        setTimeout(function(){ location.href = '@Html.Raw(refreshUrl)'; }, @(Model.PageRefreshTime) * 1000);
     </script>
 }
 


### PR DESCRIPTION
The refresh URL was being url-encoded incorrectly.